### PR TITLE
Fix `this.subject()` usage within `moduleForModel`.

### DIFF
--- a/__testfixtures__/ember-qunit-codemod/subject.output.js
+++ b/__testfixtures__/ember-qunit-codemod/subject.output.js
@@ -21,11 +21,11 @@ module('Unit | Model | Foo', function(hooks) {
   setupTest(hooks);
 
   test('has some thing', function (assert) {
-    let subject = this.owner.factoryFor('model:foo').create();
+    let subject = this.owner.lookup('service:store').createRecord('foo');
   });
 
   test('has another thing', function (assert) {
-    let subject = this.owner.factoryFor('model:foo').create({ size: 'big' });
+    let subject = this.owner.lookup('service:store').createRecord('foo', { size: 'big' });
   });
 });
 
@@ -33,7 +33,7 @@ module('Integration | Model | Foo', function(hooks) {
   setupTest(hooks);
 
   test('has some thing', function (assert) {
-    let subject = this.owner.factoryFor('model:foo').create();
+    let subject = this.owner.lookup('service:store').createRecord('foo');
   });
 });
 
@@ -41,7 +41,7 @@ module('Unit | Model | Foo', function(hooks) {
   setupTest(hooks);
 
   test('has some thing', function (assert) {
-    let subject = this.owner.factoryFor('model:foo').create();
+    let subject = this.owner.lookup('service:store').createRecord('foo');
   });
 });
 

--- a/ember-qunit-codemod.js
+++ b/ember-qunit-codemod.js
@@ -246,7 +246,7 @@ module.exports = function(file, api, options) {
 
       thisDotSubjectUsage.forEach(p => {
         let options = p.node.arguments[0];
-        let subjectType = subject.value.split(':')[0];
+        let [subjectType, subjectName] = subject.value.split(':');
         let isSingletonSubject = !['model', 'component'].includes(subjectType);
 
         // if we don't have `options` and the type is a singleton type
@@ -259,6 +259,22 @@ module.exports = function(file, api, options) {
                 j.identifier('lookup')
               ),
               [subject]
+            )
+          );
+        } else if (subjectType === 'model') {
+          p.replace(
+            j.callExpression(
+              j.memberExpression(
+                j.callExpression(
+                  j.memberExpression(
+                    j.memberExpression(j.thisExpression(), j.identifier('owner')),
+                    j.identifier('lookup')
+                  ),
+                  [j.literal('service:store')]
+                ),
+                j.identifier('createRecord')
+              ),
+              [j.literal(subjectName), options].filter(Boolean)
             )
           );
         } else {


### PR DESCRIPTION
Prior to this change we transformed `this.subject()` within a `moduleForModel` into:

```js
this.owner.factoryFor('model:foo').create()
```

But Ember Data models cannot be manually created (they _*must*_ be created by the store).

This change fixes the output to now be:

```js
this.owner.lookup('service:store').createRecord('foo')
```

After reviewing the [underlying code](https://github.com/emberjs/ember-test-helpers/blob/master/addon-test-support/legacy-0-6-x/test-module-for-model.js#L48-L55) in `moduleForModel` this mirrors the behavior done in ember-qunit@2.

Fixes #18