### PR TITLE
Support custom non-lifecycle methods in options.

### DIFF
--- a/__testfixtures__/ember-qunit-codemod/custom-functions-in-options.input.js
+++ b/__testfixtures__/ember-qunit-codemod/custom-functions-in-options.input.js
@@ -1,0 +1,26 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('stuff:here', {
+  customFunction() {
+    return stuff();
+  }
+});
+
+test('users customFunction', function(assert) {
+  let custom = this.customFunction();
+});
+
+moduleFor('stuff:here', {
+  customFunction() {
+    return stuff();
+  },
+
+  otherThing(basedOn) {
+    return this.blah(basedOn);
+  }
+});
+
+test('can have two', function(assert) {
+  let custom = this.customFunction();
+  let other = this.otherThing();
+});

--- a/__testfixtures__/ember-qunit-codemod/custom-functions-in-options.output.js
+++ b/__testfixtures__/ember-qunit-codemod/custom-functions-in-options.output.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('stuff:here', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.customFunction = function() {
+      return stuff();
+    };
+  });
+
+  test('users customFunction', function(assert) {
+    let custom = this.customFunction();
+  });
+});
+
+module('stuff:here', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.customFunction = function() {
+      return stuff();
+    };
+
+    this.otherThing = function(basedOn) {
+      return this.blah(basedOn);
+    };
+  });
+
+  test('can have two', function(assert) {
+    let custom = this.customFunction();
+    let other = this.otherThing();
+  });
+});

--- a/__testfixtures__/ember-qunit-codemod/subject.input.js
+++ b/__testfixtures__/ember-qunit-codemod/subject.input.js
@@ -55,3 +55,13 @@ test('has some thing', function (assert) {
 test('has another thing', function (assert) {
   let subject = this.subject({ size: 'big' });
 });
+
+moduleFor('service:foo', {
+  subject() {
+    return derp();
+  }
+});
+
+test('can use custom subject', function(assert) {
+  let subject = this.subject();
+});

--- a/__testfixtures__/ember-qunit-codemod/subject.output.js
+++ b/__testfixtures__/ember-qunit-codemod/subject.output.js
@@ -56,3 +56,17 @@ module('Unit | Component | FooBar', function(hooks) {
     let subject = this.owner.factoryFor('component:foo-bar').create({ size: 'big' });
   });
 });
+
+module('service:foo', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.subject = function() {
+      return derp();
+    };
+  });
+
+  test('can use custom subject', function(assert) {
+    let subject = this.subject();
+  });
+});

--- a/ember-qunit-codemod.js
+++ b/ember-qunit-codemod.js
@@ -104,7 +104,7 @@ module.exports = function(file, api, options) {
   function parseModule(p) {
     let calleeName = p.node.expression.callee.name;
     // Find the moduleName and the module's options
-    let moduleName, subject, options;
+    let moduleName, subject, options, hasCustomSubject;
     let calleeArguments = p.node.expression.arguments.slice();
     let lastArgument = calleeArguments[calleeArguments.length - 1];
     if (lastArgument.type === 'ObjectExpression') {
@@ -127,9 +127,11 @@ module.exports = function(file, api, options) {
       } else if (!hasIntegration) {
         subject = calleeArguments[0];
       }
+
+      hasCustomSubject = options.properties.some(p => p.key.name === 'subject');
     }
 
-    return [moduleName, options, setupIdentifier, subject];
+    return [moduleName, options, setupIdentifier, subject, hasCustomSubject];
   }
 
   function updateModuleForToNestedModule() {
@@ -155,7 +157,7 @@ module.exports = function(file, api, options) {
     }
 
     function createModule(p) {
-      let [moduleName, options, setupType, subject] = parseModule(p);
+      let [moduleName, options, setupType, subject, hasCustomSubject] = parseModule(p);
 
       // Create the new `module(moduleName, function(hooks) {});` invocation
       let callback = j.functionExpression(
@@ -186,7 +188,7 @@ module.exports = function(file, api, options) {
         });
       }
 
-      return [moduleInvocation, callback.body.body, setupType, subject];
+      return [moduleInvocation, callback.body.body, setupType, subject, hasCustomSubject];
     }
 
     function processRenderingTest(testExpression) {
@@ -301,7 +303,7 @@ module.exports = function(file, api, options) {
     let bodyPath = programPath.get('body');
 
     let bodyReplacement = [];
-    let currentModuleCallbackBody, currentTestType, currentSubject;
+    let currentModuleCallbackBody, currentTestType, currentSubject, currentHasCustomSubject;
     bodyPath.each(expressionPath => {
       let expression = expressionPath.node;
       if (isModuleDefinition(expressionPath)) {
@@ -310,12 +312,13 @@ module.exports = function(file, api, options) {
         currentModuleCallbackBody = result[1];
         currentTestType = result[2];
         currentSubject = result[3];
+        currentHasCustomSubject = result[4];
       } else if (currentModuleCallbackBody) {
         currentModuleCallbackBody.push(expression);
 
         if (currentTestType === 'setupRenderingTest') {
           processRenderingTest(expression);
-        } else if (currentTestType === 'setupTest') {
+        } else if (currentTestType === 'setupTest' && !currentHasCustomSubject) {
           processSubject(expression, currentSubject);
         }
       } else {


### PR DESCRIPTION
Prior to this change any custom methods in the options object passed into `moduleFor` would be completely lost after running the codemod.

Now these methods are preserved and properly setup on the test context.

Fixes #12