### PR TITLE
Ensure `getOwner(this)` is only rewritten in test context.

### DIFF
--- a/__testfixtures__/ember-qunit-codemod/get-owner-this.input.js
+++ b/__testfixtures__/ember-qunit-codemod/get-owner-this.input.js
@@ -1,3 +1,4 @@
+import Service from '@ember/service';
 import { moduleFor, test } from 'ember-qunit';
 
 moduleFor('service:flash', 'Unit | Service | Flash', {
@@ -25,4 +26,29 @@ moduleFor('service:flash', 'Unit | Service | Flash', {
 
 test('can use Ember.getOwner(this) also', function (assert) {
   let owner = Ember.getOwner(this);
+});
+
+test('objects registered can continue to use `getOwner(this)`', function(assert) {
+  this.register('service:foo', Service.extend({
+    someMethod() {
+      let owner = getOwner(this);
+      return owner.lookup('other:thing').someMethod();
+    }
+  }));
+});
+
+moduleFor('service:flash', {
+  beforeEach() {
+    this.blah = getOwner(this).lookup('service:blah');
+    this.register('service:foo', Service.extend({
+      someMethod() {
+        let owner = getOwner(this);
+        return owner.lookup('other:thing').someMethod();
+      }
+    }));
+  }
+});
+
+test('can use getOwner(this) in beforeEach for each context', function (assert) {
+  // stuff
 });

--- a/__testfixtures__/ember-qunit-codemod/get-owner-this.output.js
+++ b/__testfixtures__/ember-qunit-codemod/get-owner-this.output.js
@@ -1,3 +1,4 @@
+import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
@@ -26,5 +27,32 @@ module('Unit | Service | Flash', function(hooks) {
 
   test('can use Ember.getOwner(this) also', function (assert) {
     let owner = this.owner;
+  });
+
+  test('objects registered can continue to use `getOwner(this)`', function(assert) {
+    this.owner.register('service:foo', Service.extend({
+      someMethod() {
+        let owner = getOwner(this);
+        return owner.lookup('other:thing').someMethod();
+      }
+    }));
+  });
+});
+
+module('service:flash', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.blah = this.owner.lookup('service:blah');
+    this.owner.register('service:foo', Service.extend({
+      someMethod() {
+        let owner = getOwner(this);
+        return owner.lookup('other:thing').someMethod();
+      }
+    }));
+  });
+
+  test('can use getOwner(this) in beforeEach for each context', function (assert) {
+    // stuff
   });
 });


### PR DESCRIPTION
Previously, all usages of `getOwner(this)` were rewritten throughout the entire file being transformed. This causes issues when _some_ usages of `getOwner(this)` need to be left intact, while others need to be rewritten.

This PR limits processing of `getOwner(this)` -> `this.owner` to only the `test` callback functions root scope and all of the methods found in the `options` hash. See fixtures for examples.

Fixes #28