### PR TITLE
Modify `wait` rewriting to be more intelligent.

### DIFF
--- a/__testfixtures__/ember-qunit-codemod/global-wait.input.js
+++ b/__testfixtures__/ember-qunit-codemod/global-wait.input.js
@@ -1,0 +1,10 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('something');
+
+test('uses global helpers', function(assert) {
+  visit('/something');
+
+  wait().then(() => assert.ok(true));
+});

--- a/__testfixtures__/ember-qunit-codemod/global-wait.output.js
+++ b/__testfixtures__/ember-qunit-codemod/global-wait.output.js
@@ -1,0 +1,10 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+
+moduleForAcceptance('something');
+
+test('uses global helpers', function(assert) {
+  visit('/something');
+
+  wait().then(() => assert.ok(true));
+});

--- a/__testfixtures__/ember-qunit-codemod/module-for-component.input.js
+++ b/__testfixtures__/ember-qunit-codemod/module-for-component.input.js
@@ -1,4 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
+import wait from 'ember-test-helpers/wait';
 import hbs from 'htmlbars-inline-precompile';
 
 moduleForComponent('foo-bar', 'Integration | Component | FooBar', {
@@ -68,5 +69,7 @@ moduleForComponent('foo-bar', 'Integration | Component | FooBar', {
 });
 
 test('can use render in custom method', function (assert) {
-  assert.equal(this._element.textContent, 'derp');
+  return wait().then(() => {
+    assert.equal(this._element.textContent, 'derp');
+  });
 });

--- a/__testfixtures__/ember-qunit-codemod/module-for-component.output.js
+++ b/__testfixtures__/ember-qunit-codemod/module-for-component.output.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest, setupTest } from 'ember-qunit';
-import { clearRender, render } from 'ember-test-helpers';
+import { clearRender, render, settled } from 'ember-test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Component | FooBar', function(hooks) {
@@ -71,6 +71,8 @@ module('Integration | Component | FooBar', function(hooks) {
   });
 
   test('can use render in custom method', function (assert) {
-    assert.equal(this.element.textContent, 'derp');
+    return settled().then(() => {
+      assert.equal(this.element.textContent, 'derp');
+    });
   });
 });


### PR DESCRIPTION
* Only update when `ember-test-helpers/wait` was imported
* Only update the actual imported name to `settled`
* Unconditionally update `wait` import when found (was previously only happening in non-test files?!?!).

Fixes #35