### PR TITLE
 Prevent line breaks in module() invocation

### DIFF
--- a/__testfixtures__/ember-qunit-codemod/module-with-long-name.input.js
+++ b/__testfixtures__/ember-qunit-codemod/module-with-long-name.input.js
@@ -1,0 +1,7 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:foo', 'Unit | Service | Foo with a very long name that would cause line breaks');
+
+test('it happens', function() {
+
+});

--- a/__testfixtures__/ember-qunit-codemod/module-with-long-name.output.js
+++ b/__testfixtures__/ember-qunit-codemod/module-with-long-name.output.js
@@ -1,0 +1,10 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | Foo with a very long name that would cause line breaks', function(hooks) {
+  setupTest(hooks);
+
+  test('it happens', function() {
+
+  });
+});


### PR DESCRIPTION
Using `j.callExpression()` builds this:

```js
module(
  'some loooooooooooong name',
  function(hooks) {
    setupTest(hooks);
  }
);
```

but we want to enforce not having line breaks in the module() invocation so we'll have to use a little hack to get this:

```js
module('some loooooooooooong name', function(hooks) {
  setupTest(hooks);
});
```
