### PR TITLE
Ensure running codemod against transformed files is a no-op.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,4 +17,12 @@ module.exports = {
       printWidth: 100,
     }],
   },
+  overrides: [
+    {
+      files: ['__tests__/**/*.js'],
+      env: {
+        jest: true
+      }
+    },
+  ],
 };

--- a/__tests__/ember-qunit-codemod-test.js
+++ b/__tests__/ember-qunit-codemod-test.js
@@ -1,18 +1,40 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 
-const defineTest = require('jscodeshift/dist/testUtils').defineTest;
+const runInlineTest = require('jscodeshift/dist/testUtils').runInlineTest;
+const EmberQUnitTransform = require('../ember-qunit-codemod');
+
 const fixtureFolder = `${__dirname}/../__testfixtures__/ember-qunit-codemod`;
 
-fs
-  .readdirSync(fixtureFolder)
-  .filter(filename => /\.input\.js$/.test(filename))
-  .forEach(filename => {
-    defineTest(
-      __dirname,
-      'ember-qunit-codemod',
-      {},
-      `ember-qunit-codemod/${filename.replace(/\.input\.js$/, '')}`
-    );
-  });
+describe('ember-qunit-codemod', function() {
+  fs
+    .readdirSync(fixtureFolder)
+    .filter(filename => /\.input\.js$/.test(filename))
+    .forEach(filename => {
+      let testName = filename.replace('.input.js', '');
+      let inputPath = path.join(fixtureFolder, `${testName}.input.js`);
+      let outputPath = path.join(fixtureFolder, `${testName}.output.js`);
+
+      describe(testName, function() {
+        it('transforms correctly', function() {
+          runInlineTest(
+            EmberQUnitTransform,
+            {},
+            { source: fs.readFileSync(inputPath, 'utf8') },
+            fs.readFileSync(outputPath, 'utf8')
+          );
+        });
+
+        it('is idempotent', function() {
+          runInlineTest(
+            EmberQUnitTransform,
+            {},
+            { source: fs.readFileSync(outputPath, 'utf8') },
+            fs.readFileSync(outputPath, 'utf8')
+          );
+        });
+      });
+    });
+});


### PR DESCRIPTION
* Update test suite to ensure that running transform against "pre-transformed" files changes nothing.
* Fix issues when input includes nested modules already.

Fixes https://github.com/rwjblue/ember-qunit-codemod/issues/52