### PR TITLE
moduleForAcceptance codemod

### DIFF
--- a/__testfixtures__/ember-qunit-codemod/global-wait.output.js
+++ b/__testfixtures__/ember-qunit-codemod/global-wait.output.js
@@ -1,10 +1,14 @@
-import { test } from 'qunit';
-import moduleForAcceptance from '../helpers/module-for-acceptance';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit } from '@ember/test-helpers';
 
-moduleForAcceptance('something');
+module('something', function(hooks) {
+  setupApplicationTest(hooks);
 
-test('uses global helpers', function(assert) {
-  visit('/something');
+  test('uses global helpers', async function(assert) {
+    await visit('/something');
 
-  wait().then(() => assert.ok(true));
+    wait().then(() => assert.ok(true));
+  });
 });
+

--- a/__testfixtures__/ember-qunit-codemod/module-for-acceptance.input.js
+++ b/__testfixtures__/ember-qunit-codemod/module-for-acceptance.input.js
@@ -80,6 +80,17 @@ test('it works with nested', function() {
   });
 });
 
+test('it works with nested andThens', function() {
+  visit('my-route');
+  andThen(function() {
+    assert.equal(currenURL(), 'my-route');
+    visit('other-route');
+    andThen(function() {
+      assert.equal(currenURL(), 'other-route');
+    });
+  });
+});
+
 test('it works with assert.expect', function() {
   assert.expect(2);
   visit('my-route');

--- a/__testfixtures__/ember-qunit-codemod/module-for-acceptance.input.js
+++ b/__testfixtures__/ember-qunit-codemod/module-for-acceptance.input.js
@@ -1,0 +1,93 @@
+import { test } from 'ember-qunit';
+import { test } from 'qunit';
+import moduleForAcceptance from '../helpers/module-for-acceptance';
+import { setupTestHelper } from 'setup-test-helper';
+
+moduleForAcceptance('Acceptance | MyRoute', {
+  beforeEach() {
+    // my comment
+    setupTestHelper();
+  }
+});
+
+test('it happens', function() {
+  visit('my-route');
+  andThen(() => {
+    assert.equal(currentURL(), 'wat');
+  });
+});
+
+moduleForAcceptance('Acceptance | ES5 MyRoute', {
+  beforeEach: function() {
+    setupTestHelper();
+  }
+});
+
+test('it happens with es5 function', function() {
+  visit('my-route');
+  andThen(() => {
+    // visit me
+    assert.equal(currentURL(), 'wat');
+    assert.equal(currentURL(), 'wat');
+    assert.equal(currentRouteName(), 'wat');
+  });
+});
+
+moduleForAcceptance('Acceptance | OtherRoute', {
+  beforeEach() {}
+});
+
+test('it happens with find', function() {
+  visit('my-route');
+  blur('#my-input');
+  click('#my-block');
+  find('#my-block');
+  fillIn('#my-input', 'codemod');
+  focus('#my-input');
+  tap('#my-input');
+  triggerEvent('#my-input', 'focusin');
+  triggerKeyEvent('#my-input', 'keyup', 13);
+});
+
+moduleForAcceptance('Acceptance | AndThenRoute');
+
+test('it works with andThen', function() {
+  visit('my-route');
+  andThen(() => {
+    assert.ok(true);
+    assert.ok(false);
+  });
+  find('#my-block');
+});
+
+test('it works with es5 andThen', function() {
+  visit('my-route');
+  andThen(function() {
+    assert.ok(true);
+    assert.ok(false);
+  });
+  find('#my-block');
+});
+
+test('it works with nested', function() {
+  visit('my-route');
+  andThen(function() {
+    assert.equal(currenURL(), 'my-route');
+    visit('other-route');
+  });
+  andThen(function() {
+    assert.equal(currenURL(), 'other-route');
+  });
+});
+
+test('it works with assert.expect', function() {
+  assert.expect(2);
+  visit('my-route');
+  andThen(function() {
+    assert.equal(currenURL(), 'my-route');
+    visit('other-route');
+  });
+  andThen(function() {
+    assert.equal(currenURL(), 'other-route');
+  });
+});

--- a/__testfixtures__/ember-qunit-codemod/module-for-acceptance.output.js
+++ b/__testfixtures__/ember-qunit-codemod/module-for-acceptance.output.js
@@ -75,6 +75,13 @@ module('Acceptance | AndThenRoute', function(hooks) {
     assert.equal(currenURL(), 'other-route');
   });
 
+  test('it works with nested andThens', async function() {
+    await visit('my-route');
+    assert.equal(currenURL(), 'my-route');
+    await visit('other-route');
+    assert.equal(currenURL(), 'other-route');
+  });
+
   test('it works with assert.expect', async function() {
     assert.expect(2);
     await visit('my-route');

--- a/__testfixtures__/ember-qunit-codemod/module-for-acceptance.output.js
+++ b/__testfixtures__/ember-qunit-codemod/module-for-acceptance.output.js
@@ -1,0 +1,85 @@
+import { module, test } from 'qunit';
+import { setupTestHelper } from 'setup-test-helper';
+
+import { setupApplicationTest } from 'ember-qunit';
+import { blur, click, currentRouteName, currentURL, fillIn, find, focus, tap, triggerEvent, triggerKeyEvent, visit } from '@ember/test-helpers';
+
+module('Acceptance | MyRoute', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    // my comment
+    setupTestHelper();
+  });
+
+  test('it happens', async function() {
+    await visit('my-route');
+    assert.equal(currentURL(), 'wat');
+  });
+});
+
+module('Acceptance | ES5 MyRoute', function(hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(function() {
+    setupTestHelper();
+  });
+
+  test('it happens with es5 function', async function() {
+    await visit('my-route');
+    // visit me
+    assert.equal(currentURL(), 'wat');
+    assert.equal(currentURL(), 'wat');
+    assert.equal(currentRouteName(), 'wat');
+  });
+});
+
+module('Acceptance | OtherRoute', function(hooks) {
+  setupApplicationTest(hooks);
+  hooks.beforeEach(function() {});
+
+  test('it happens with find', async function() {
+    await visit('my-route');
+    await blur('#my-input');
+    await click('#my-block');
+    await find('#my-block');
+    await fillIn('#my-input', 'codemod');
+    await focus('#my-input');
+    await tap('#my-input');
+    await triggerEvent('#my-input', 'focusin');
+    await triggerKeyEvent('#my-input', 'keyup', 13);
+  });
+});
+
+module('Acceptance | AndThenRoute', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('it works with andThen', async function() {
+    await visit('my-route');
+    assert.ok(true);
+    assert.ok(false);
+    await find('#my-block');
+  });
+
+  test('it works with es5 andThen', async function() {
+    await visit('my-route');
+    assert.ok(true);
+    assert.ok(false);
+    await find('#my-block');
+  });
+
+  test('it works with nested', async function() {
+    await visit('my-route');
+    assert.equal(currenURL(), 'my-route');
+    await visit('other-route');
+    assert.equal(currenURL(), 'other-route');
+  });
+
+  test('it works with assert.expect', async function() {
+    assert.expect(2);
+    await visit('my-route');
+    assert.equal(currenURL(), 'my-route');
+    await visit('other-route');
+    assert.equal(currenURL(), 'other-route');
+  });
+});

--- a/ember-qunit-codemod.js
+++ b/ember-qunit-codemod.js
@@ -456,8 +456,18 @@ module.exports = function(file, api) {
       });
 
       // Second - Transform to await visit(), click, fillIn, touch, etc and adds `async` to scope
-      ['visit', 'find', 'waitFor', 'fillIn', 'click', 'blur', 'focus', 'tap',
-        'triggerEvent', 'triggerKeyEvent'].forEach(type => {
+      [
+        'visit',
+        'find',
+        'waitFor',
+        'fillIn',
+        'click',
+        'blur',
+        'focus',
+        'tap',
+        'triggerEvent',
+        'triggerKeyEvent',
+      ].forEach(type => {
         findApplicationTestHelperUsageOf(testExpressionCollection, type).forEach(p => {
           specifiers.add(type);
 
@@ -473,15 +483,14 @@ module.exports = function(file, api) {
 
       // Third - update call expressions that do not await
       ['currentURL', 'currentRouteName'].forEach(type => {
-        testExpressionCollection.find(j.CallExpression, {
-          callee: {
-            type: 'Identifier',
-            name: type,
-          },
-        })
-        .forEach(() => {
-          specifiers.add(type);
-        });
+        testExpressionCollection
+          .find(j.CallExpression, {
+            callee: {
+              type: 'Identifier',
+              name: type,
+            },
+          })
+          .forEach(() => specifiers.add(type));
       });
 
       ensureImportWithSpecifiers({


### PR DESCRIPTION
This is a basic setup to migrate acceptance tests.

Right now, as is, there would be a few caveats and work that would have to be done by the end user.  `find` and `findAll` are not in this lib, but I would be happy to help get that in there.  Second, jquery statements like `:eq` would not be migrated properly but wouldn't be too hard to migrate.  Lastly, I haven't tested w/ ember-cli-page-object but I would imagine that would also be a caveat as well.