### PR TITLE
Added jscodeshift install and warning message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ This codemod is intended to automatically convert your projects from the older
 ## Installation
 
 ```sh
+npm install -g jscodeshift
 npm install -g ember-qunit-codemod
 ```
 
 ## Usage
+**WARNING**: `jscodeshift`, and thus this codemod, **edits your files in place**.
+It does not make a copy. Make sure your code is checked into a source control
+repository like Git and that you have no outstanding changes to commit before
+running this tool.
 
 ```sh
 ember-qunit-codemod ./tests/


### PR DESCRIPTION
I spent entirely too much time wondering why the codemod wasn't actually doing anything. I didn't realize what was happening until I looked inside the cli.js file and realized I didn't have jscodeshift installed. 

Warning copied from ember-test-helpers codemod because it seemed like an excellent idea.